### PR TITLE
Add Microsoft-Symbol-Server as that is the header Rider uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Configure GitLab nginx to proxy the Visual Studio requests through our proxy:
 vim /var/opt/gitlab/nginx/conf/gitlab-http.conf 
 ...
   location / {
-    if ($http_user_agent ~ "SourceLink") {
+    if ($http_user_agent ~ "(Microsoft-Symbol-Server|SourceLink)") {
       #proxy_set_header Authorization "Basic cm9vdDpwYXNzd29yZA==";
       proxy_pass http://127.0.0.1:7000;
       break;


### PR DESCRIPTION
Here is the capture of rider trying to use sourcelink.
![image](https://user-images.githubusercontent.com/1661688/75231995-bcb71180-57b6-11ea-8ef8-aea368cdcf98.png)
